### PR TITLE
Added Zonetraces

### DIFF
--- a/app/components.js
+++ b/app/components.js
@@ -377,7 +377,43 @@ var StackTrace = React.createClass({
   }
 });
 
+var ZoneList = React.createClass({
+  printSize: function(bytes) {
+    if (bytes < (1 << 10)) {
+      return bytes + " B";
+    } else if (bytes < (1 << 20)) {
+      return (bytes / (1 << 10)) + " KB";
+    } else if (bytes < (1 << 30)) {
+      return (bytes / (1 << 20)) + " MB";
+    }
+  },  
+  
+  keysBySize: function() {
+    return Object.keys(this.props.zones)
+      .sort((a, b) => this.props.zones[b].size - this.props.zones[a].size);
+  },
+
+  render: function() {
+    return (
+      <div>
+        <h3>Zones</h3>
+        <ul>
+          { 
+            this.keysBySize().map((key, idx) => {
+              return (<li key={idx}>
+                Zone: {key}, 
+                Name: {this.props.zones[key].name} <br />
+                Size: {this.printSize(this.props.zones[key].size)}
+              </li>);
+          })}
+        </ul>
+      </div>
+    );
+  }
+});
+
 module.exports = {
   InstanceTypeDetails: InstanceTypeDetails,
-  StackTrace: StackTrace
+  StackTrace: StackTrace,
+  ZoneList: ZoneList
 };

--- a/app/trace-file-reader.js
+++ b/app/trace-file-reader.js
@@ -32,6 +32,7 @@ export default React.createClass({
             data[entry.isolate] = {
               nonEmptyInstanceTypes: new Set(),
               gcs: {},
+              zonetags: [],
               samples: {
                 zone: {}
               },
@@ -55,6 +56,22 @@ export default React.createClass({
             const stacktrace = ("stacktrace" in entry) ? entry.stacktrace : [];
             data[entry.isolate].samples.zone[entry.time] =
               {allocated: entry.allocated, pooled: entry.pooled, stacktrace: stacktrace};
+            if (entry.time > data[entry.isolate].end)
+              data[entry.isolate].end = entry.time;
+            if (data[entry.isolate].start === null)
+              data[entry.isolate].start = entry.time;
+          } else if (entry.type === "zonecreation" || entry.type === "zonedestruction") {
+            createEntryIfNeeded(entry);
+            var tag = {
+                opening: entry.type === "zonecreation",
+                time: entry.time,
+                ptr: entry.ptr,
+                name: entry.name,
+                size: entry.size
+            };
+            
+            data[entry.isolate].zonetags.push(tag);
+            
             if (entry.time > data[entry.isolate].end)
               data[entry.isolate].end = entry.time;
             if (data[entry.isolate].start === null)


### PR DESCRIPTION
Depends on https://github.com/mlippautz/v8-heap-stats/pull/1, please merge before!

![zonetraces](https://cloud.githubusercontent.com/assets/3444034/19165129/ea36aa4a-8c02-11e6-9c8b-dfc0a67fbaba.png)

The zone memory graph can be clicked and the zones alive at that point are outputted ordered by size. No names given for zones so far, this will happen in a separate CL to the v8 repository.

Depends on the v8 CL https://codereview.chromium.org/2397573007.
