### PR TITLE
Added detailed size information

### DIFF
--- a/app/components.js
+++ b/app/components.js
@@ -390,7 +390,7 @@ var ZoneList = React.createClass({
 
   keysBySize: function() {
     return Object.keys(this.props.zones)
-      .sort((a, b) => this.props.zones[b].size - this.props.zones[a].size);
+      .sort((a, b) => this.props.zones[b].size.total - this.props.zones[a].size.total);
   },
 
   render: function() {
@@ -403,7 +403,12 @@ var ZoneList = React.createClass({
               return (<li key={idx}>
                 Zone: {key},
                 Name: {this.props.zones[key].name} <br />
-                Size: {this.printSize(this.props.zones[key].size)}
+                <strong>
+                Total Size: {this.printSize(this.props.zones[key].size.total)},
+                </strong>
+                Used Size: {this.printSize(this.props.zones[key].size.used)}, 
+                Wasted Size: {this.printSize(this.props.zones[key].size.wasted)}, 
+                Header Size: {this.printSize(this.props.zones[key].size.segment_header)} 
               </li>);
             })}
         </ul>

--- a/app/trace-file-reader.js
+++ b/app/trace-file-reader.js
@@ -67,7 +67,12 @@ export default React.createClass({
               time: entry.time,
               ptr: entry.ptr,
               name: entry.name,
-              size: entry.size
+              size: {
+                total: entry.total_size,
+                used: entry.used_size,
+                segment_header: entry.segment_header_size,
+                wasted: entry.wasted_size
+              }
             };
 
             data[entry.isolate].zonetags.push(tag);

--- a/app/v8-heap-stats.js
+++ b/app/v8-heap-stats.js
@@ -343,7 +343,7 @@ export default React.createClass({
         };
       }
     }
-
+    
     this.setState({
       data: this.state.data,
       threshold: this.state.threshold,


### PR DESCRIPTION
Differentiates between the 
- **total** size of segments allocated
- size actually _used_ to allocate objects in the zone
- the _wasted_ size that was left behind when allocating new segments
- the segment _header_ size

Linked to V8-CL https://codereview.chromium.org/2411383002
